### PR TITLE
fix: add url-encoding to gitlab owner/group when building api url

### DIFF
--- a/lua/validate-gitlab-ci/validate-gitlab-ci.lua
+++ b/lua/validate-gitlab-ci/validate-gitlab-ci.lua
@@ -76,7 +76,7 @@ local function validate_job()
   local url = "https://"
     .. git_info.host
     .. "/api/v4/projects/"
-    .. git_info.owner
+    .. string.gsub(git_info.owner, "/", "%%2F")
     .. "%2F"
     .. git_info.repo
     .. "/ci/lint"


### PR DESCRIPTION
Fixes: https://github.com/sbulav/validate-gitlab-ci.nvim/issues/1